### PR TITLE
update to oauth2client 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "wagtail>=0.8.7",
         "Django>=1.7.1",
         "google-api-python-client==1.5.0",
-        "oauth2client==1.5.2",
+        "oauth2client<3,>=2.0.0",
         "wagtailfontawesome"
     ],
 )

--- a/wagalytics/views.py
+++ b/wagalytics/views.py
@@ -1,5 +1,5 @@
 import json
-from oauth2client.client import SignedJwtAssertionCredentials
+from oauth2client.service_account import ServiceAccountCredentials
 from django.shortcuts import redirect, render
 from django.conf import settings
 
@@ -9,16 +9,12 @@ def get_access_token(ga_key_filepath):
     # Defines a method to get an access token from the credentials object.
     # The access token is automatically refreshed if it has expired.
 
-    # Load the key file's private data.
-    with open(ga_key_filepath) as key_file:
-        _key_data = json.load(key_file)
-
     # The scope for the OAuth2 request.
     SCOPE = 'https://www.googleapis.com/auth/analytics.readonly'
 
     # Construct a credentials objects from the key data and OAuth2 scope.
-    _credentials = SignedJwtAssertionCredentials(
-        _key_data['client_email'], _key_data['private_key'], SCOPE)
+    _credentials = ServiceAccountCredentials.from_json_keyfile_name(
+        ga_key_filepath, SCOPE)
 
     return _credentials.get_access_token().access_token
 


### PR DESCRIPTION
`google-api-python-client` requires `oauth2client<3,>=2.0.0`, so I updated wagalytics to the same version and fixed the breaking changes.