### PR TITLE
Enable usage of a string as private key input instead of a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This module provides a simple dashboard of Google Analytics data, integrated int
 1. Add 'wagtailfontawesome' to INSTALLED_APPS if it's not there already
 1. Update your settings:
  - `GA_KEY_FILEPATH = '/path/to/secure/directory/your-key.json'`
+ or when using environment variables (e.g. Heroku)
+ - `GA_KEY_CONTENT = 'content_of_your_key.json'`
  - `GA_VIEW_ID = 'ga:xxxxxxxx'`
 
 If you get CryptoUnavailableError errors, you probably need to `pip install PyOpenSSL` and/or `pip install pycrypto`. See [StackOverflow](http://stackoverflow.com/questions/27305867/google-api-access-using-service-account-oauth2client-client-cryptounavailableerr).

--- a/wagalytics/views.py
+++ b/wagalytics/views.py
@@ -28,8 +28,9 @@ def get_access_token_from_str(ga_key_content):
     SCOPE = 'https://www.googleapis.com/auth/analytics.readonly'
 
     # Construct a credentials objects from the key data and OAuth2 scope.
+    keyDict = json.loads(ga_key_content.replace('\n', '').replace('\r', ''))
     _credentials = ServiceAccountCredentials.from_json_keyfile_dict(
-        ga_key_content, SCOPE)
+        keyDict, SCOPE)
 
     return _credentials.get_access_token().access_token
 

--- a/wagalytics/views.py
+++ b/wagalytics/views.py
@@ -19,10 +19,28 @@ def get_access_token(ga_key_filepath):
 
     return _credentials.get_access_token().access_token
 
+def get_access_token_from_str(ga_key_content):
+    # from https://ga-dev-tools.appspot.com/embed-api/server-side-authorization/
+    # Defines a method to get an access token from the credentials object.
+    # The access token is automatically refreshed if it has expired.
+
+    # The scope for the OAuth2 request.
+    SCOPE = 'https://www.googleapis.com/auth/analytics.readonly'
+
+    # Construct a credentials objects from the key data and OAuth2 scope.
+    _credentials = ServiceAccountCredentials.from_json_keyfile_dict(
+        ga_key_content, SCOPE)
+
+    return _credentials.get_access_token().access_token
+
 @cache_page(3600)
 def token(request):
     # return a cached access token to ajax clients
-    access_token = get_access_token(settings.GA_KEY_FILEPATH)
+    if (settings.GA_KEY_CONTENT != ''):
+        access_token = get_access_token_from_str(settings.GA_KEY_CONTENT)
+    else:
+        access_token = get_access_token(settings.GA_KEY_FILEPATH)
+
     return HttpResponse(access_token)
 
 def dashboard(request):

--- a/wagalytics/views.py
+++ b/wagalytics/views.py
@@ -36,7 +36,7 @@ def get_access_token_from_str(ga_key_content):
 @cache_page(3600)
 def token(request):
     # return a cached access token to ajax clients
-    if (settings.GA_KEY_CONTENT != ''):
+    if (hasattr(settings, 'GA_KEY_CONTENT') and settings.GA_KEY_CONTENT != ''):
         access_token = get_access_token_from_str(settings.GA_KEY_CONTENT)
     else:
         access_token = get_access_token(settings.GA_KEY_FILEPATH)


### PR DESCRIPTION
This pull-request enables the use of the module on PaaS providers with volatile file systems (e.g. heroku), where the developer has no possibility to actually create a file (apart from checking it in).