### PR TITLE
Drop unused google-api-python-client dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,7 @@ setup(
     install_requires=[
         "wagtail>=0.8.7",
         "Django>=1.7.1",
-        "google-api-python-client==1.5.5",
-        "oauth2client<3,>=2.0.0",
+        "oauth2client",
         "wagtailfontawesome>=1.0.2",
         "pyexcel-ods==0.5.3"
     ],


### PR DESCRIPTION
We are not actually using `google-api-python-client` at all in this app - all we need is `oauth2client` to generate an access token from credentials - this is generic oAuth2 functionality, and since we're not doing any server-side communication with Google's APIs, we don't need any more than that.