### PR TITLE
Fix broken import when installing from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,15 @@
 from os import path
 
 from setuptools import setup, find_packages
-from wagtail.utils.setup import sdist
+
+try:
+    from wagtail.utils.setup import sdist
+    cmdclass = {
+        'sdist': sdist
+    }
+except ModuleNotFoundError:
+    cmdclass = {}
+
 from wagalytics import __version__
 
 
@@ -41,9 +49,7 @@ setup(
         "wagtailfontawesome>=1.1.2",
         "pyexcel-ods==0.5.3"
     ],
-    cmdclass={
-        'sdist': sdist
-    },
+    cmdclass=cmdclass,
     extras_require={
         'testing': testing_extras,
     },


### PR DESCRIPTION
When installing `wagalytics` using a `setup.py` file it's trying to import a wagtail module that doesn't exist (yet). This try/except remedies that import error. 