### PR TITLE
Settings parsing bugfix for GA_KEY_CONTENT & GA_KEY_FILEPATH

### DIFF
--- a/wagalytics/views.py
+++ b/wagalytics/views.py
@@ -76,14 +76,14 @@ def token(request, site_id=None):
 
         if wagalytics_settings.get('GA_KEY_CONTENT', None):
             access_token = get_access_token_from_str(wagalytics_settings['GA_KEY_CONTENT'])
-        if wagalytics_settings.get('GA_KEY_FILEPATH', None):
+        elif wagalytics_settings.get('GA_KEY_FILEPATH', None):
             access_token = get_access_token(wagalytics_settings['GA_KEY_FILEPATH'])
         else:
             return HttpResponseForbidden()
     else:
         if (hasattr(settings, 'GA_KEY_CONTENT') and settings.GA_KEY_CONTENT != ''):
             access_token = get_access_token_from_str(settings.GA_KEY_CONTENT)
-        if (hasattr(settings, 'GA_KEY_FILEPATH') and settings.GA_KEY_FILEPATH != ''):
+        elif (hasattr(settings, 'GA_KEY_FILEPATH') and settings.GA_KEY_FILEPATH != ''):
             access_token = get_access_token(settings.GA_KEY_FILEPATH)
         else:
             return HttpResponseForbidden()


### PR DESCRIPTION
Commit:
>fix: prevent a missing value for GA_KEY_FILEPATH in settings from overwriting the access_token previously parsed from GA_KEY_CONTENT

```
--- a/wagalytics/views.py
+++ b/wagalytics/views.py
@@ -76,14 +76,14 @@ def token(request, site_id=None):
         if wagalytics_settings.get('GA_KEY_CONTENT', None):
             access_token = get_access_token_from_str(wagalytics_settings['GA_KEY_CONTENT'])
-        if wagalytics_settings.get('GA_KEY_FILEPATH', None):
+        elif wagalytics_settings.get('GA_KEY_FILEPATH', None):
             access_token = get_access_token(wagalytics_settings['GA_KEY_FILEPATH'])
         else:
             return HttpResponseForbidden()
     else:
         if (hasattr(settings, 'GA_KEY_CONTENT') and settings.GA_KEY_CONTENT != ''):
             access_token = get_access_token_from_str(settings.GA_KEY_CONTENT)
-        if (hasattr(settings, 'GA_KEY_FILEPATH') and settings.GA_KEY_FILEPATH != ''):
+        elif (hasattr(settings, 'GA_KEY_FILEPATH') and settings.GA_KEY_FILEPATH != ''):
             access_token = get_access_token(settings.GA_KEY_FILEPATH)
         else:
             return HttpResponseForbidden()
```

If you set GA_KEY_CONTENT in your settings, the current codepath will still look for GA_KEY_FILEPATH, and if it doesn't find it or it is blank, it will cause a 403 error to be raised.

Fix in this patch just changes each second if statement to elif to avoid this issue.